### PR TITLE
Add Generative AI Integrations (Google Generative AI & OpenAI)

### DIFF
--- a/Server/app.js
+++ b/Server/app.js
@@ -11,6 +11,7 @@ import { ApiRouter } from "./routers/index.js";
 import { notFoundMiddleware } from "./middleware/not_found.middleware.js";
 import { swaggerUi, swaggerSpec } from "./utils/swagger.js";
 import cookieParser from "cookie-parser";
+import groq from "./config/groq.js";
 
 const app = express();
 
@@ -46,7 +47,7 @@ app.get("/health", (req, res) => {
     res.status(200).json({ status: "ok", timestamp: new Date().toISOString() });
 });
 
-// Hide docs in production
+
 if (process.env.NODE_ENV !== "production") {
     app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 }

--- a/Server/config/gemini.js
+++ b/Server/config/gemini.js
@@ -1,0 +1,13 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+
+const model = genAI.getGenerativeModel({
+    model: "gemini-1.5-flash",
+    systemInstruction: `You are an AI assistant working inside an Online Pharmacy System. Answer briefly and clearly.`,
+});
+
+export default model;

--- a/Server/config/groq.js
+++ b/Server/config/groq.js
@@ -1,0 +1,11 @@
+import OpenAI from "openai";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const groq = new OpenAI({
+    apiKey: process.env.GROQ_API_KEY,
+    baseURL: "https://api.groq.com/openai/v1",
+});
+
+export default groq;

--- a/Server/config/openai.js
+++ b/Server/config/openai.js
@@ -1,0 +1,10 @@
+import OpenAI from "openai";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const openai = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+});
+
+export default openai;

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "bcrypt": "^6.0.0",
         "cloudinary": "^2.7.0",
         "compression": "^1.8.1",
@@ -26,6 +27,7 @@
         "morgan": "^1.10.1",
         "multer": "^2.1.1",
         "nodemailer": "^8.0.1",
+        "openai": "^6.49.0",
         "sharp": "^0.34.5",
         "slugify": "^1.6.8",
         "streamifier": "^0.1.1",
@@ -90,6 +92,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@hapi/address": {
@@ -2223,6 +2234,36 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.49.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+      "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openapi-types": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/aelaraby6/PharmaXpress#readme",
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "bcrypt": "^6.0.0",
     "cloudinary": "^2.7.0",
     "compression": "^1.8.1",
@@ -43,6 +44,7 @@
     "morgan": "^1.10.1",
     "multer": "^2.1.1",
     "nodemailer": "^8.0.1",
+    "openai": "^6.49.0",
     "sharp": "^0.34.5",
     "slugify": "^1.6.8",
     "streamifier": "^0.1.1",


### PR DESCRIPTION
### Summary
Adds initial integration setup for AI-powered responses within the Online Pharmacy System. Includes configuration and test routes for both Google Generative AI (Gemini) and OpenAI, along with related app-level configuration updates.

### Notes
- Both integrations are currently limited to simple test endpoints (`/test`) for validating connectivity and response handling.
- Google Generative AI quota returned `429` (free tier limit: 0) — pending billing/plan verification.
- OpenAI returned `429 insufficient_quota` — requires billing setup on OpenAI platform.
- **Groq** (OpenAI-compatible API) was validated as a working free alternative and may replace/supplement these providers depending on final decision — not included in this PR.